### PR TITLE
Used a throttled httpClient for license check

### DIFF
--- a/license_test.go
+++ b/license_test.go
@@ -1,14 +1,18 @@
 package helm_test
 
 import (
+	"context"
+	"fmt"
 	"io/ioutil"
-	"os"
+	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	pkggodevclient "github.com/guseggert/pkggodev-client"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/mod/modfile"
+	"golang.org/x/time/rate"
 )
 
 var (
@@ -29,13 +33,24 @@ var (
 )
 
 func TestLicenses(t *testing.T) {
-	// Set GONOPROXY environment variable
-	os.Setenv("GONOPROXY", "github.com")
+
+	// Create HTTP client with throttling and backoff retry
+	limiter := rate.NewLimiter(rate.Every(1*time.Second), 1) // 1 request per second with burst of 1
+
+	httpClient := &http.Client{
+		Timeout: 180 * time.Second,
+		Transport: &throttledTransport{
+			limiter: limiter,
+			base:    http.DefaultTransport,
+		},
+	}
+
 	b, err := ioutil.ReadFile("go.mod")
 	require.NoError(t, err)
 	file, err := modfile.Parse("go.mod", b, nil)
 	require.NoError(t, err)
-	client := pkggodevclient.New()
+
+	client := pkggodevclient.New(pkggodevclient.WithHTTPClient(httpClient))
 	for _, req := range file.Require {
 		pkg, err := client.DescribePackage(pkggodevclient.DescribePackageRequest{
 			Package: req.Mod.Path,
@@ -54,4 +69,53 @@ func TestLicenses(t *testing.T) {
 			}
 		}
 	}
+}
+
+// throttledTransport wraps an http.RoundTripper with rate limiting
+type throttledTransport struct {
+	limiter *rate.Limiter
+	base    http.RoundTripper
+}
+
+func (t *throttledTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Wait for rate limiter
+	err := t.limiter.Wait(context.Background())
+	if err != nil {
+		return nil, err
+	}
+
+	// Try the request with exponential backoff for rate limiting
+	var resp *http.Response
+	var lastErr error
+	maxRetries := 5
+	baseDelay := 2 * time.Second
+
+	for i := 0; i < maxRetries; i++ {
+		resp, lastErr = t.base.RoundTrip(req)
+		if lastErr != nil {
+			return nil, lastErr
+		}
+
+		// If we get a 429 (Too Many Requests) or 503 (Service Unavailable), retry with exponential backoff
+		if resp.StatusCode == 429 || resp.StatusCode == 503 {
+			if i < maxRetries-1 { // Don't sleep on the last attempt
+				// Exponential backoff: 2s, 4s, 8s, 16s, 32s
+				delay := baseDelay * time.Duration(1<<i)
+				// Add some jitter to avoid thundering herd
+				jitter := time.Duration(float64(delay) * 0.1 * (0.5 + 0.5*float64(i)))
+				totalDelay := delay + jitter
+
+				fmt.Printf("Rate limited (HTTP %d), retrying in %v (attempt %d/%d)\n", resp.StatusCode, totalDelay, i+1, maxRetries)
+				time.Sleep(totalDelay)
+				resp.Body.Close()
+				continue
+			} else {
+				fmt.Printf("Rate limited (HTTP %d), giving up after %d attempts\n", resp.StatusCode, maxRetries)
+			}
+		}
+
+		return resp, nil
+	}
+
+	return resp, lastErr
 }


### PR DESCRIPTION
Context
-------

License test is constantly being throttlend and getting 429 so we need to change the default httpClient with another that handles the cases

Depends on https://github.com/adevinta/go-helm-toolkit/pull/2