### PR TITLE
Fix GHA so it can clone the repo even if private

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Setup Golang caches
       uses: actions/cache@v4


### PR DESCRIPTION
Context
-------

action checkout can not find the repo when it is private. Adding auth

Change-Id: Ib903ddea60a626029fdec3de23abbd9448070acd